### PR TITLE
just `.render` method

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,17 +2,15 @@
 
 var opal = require('opalcss')
 var extend = require('extend-shallow')
-var Promise = require('promise')
 
 exports.name = 'opalcss'
-exports.inputFormats = ['opal', 'opalcss']
+exports.inputFormats = ['opal', 'opalcss', 'css', 'scss', 'sass']
 exports.outputFormat = 'css'
 
-exports.renderAsync = function (str, options, locals) {
-  return new Promise(function (resolve, reject) {
-    var opts = extend({}, options || {}, locals || {})
-    opal.process(str, opts).then(function (result) {
-      resolve(result.css)
-    }, reject)
-  })
+exports.render = function (str, opts, locals) {
+  opts = opts && typeof opts === 'object' ? opts : {}
+  locals = locals && typeof locals === 'object' ? locals : {}
+  var options = extend({}, opts, locals)
+
+  return opal.process(str, opts).css
 }

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var opal = require('opalcss')
 var extend = require('extend-shallow')
 
 exports.name = 'opalcss'
-exports.inputFormats = ['opal', 'opalcss', 'css', 'scss', 'sass']
+exports.inputFormats = ['opal', 'opalcss']
 exports.outputFormat = 'css'
 
 exports.render = function (str, opts, locals) {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
   "license": "MIT",
   "dependencies": {
     "extend-shallow": "^2.0.1",
-    "opalcss": "^0.0.2",
+    "opalcss": "^0.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   "license": "MIT",
   "dependencies": {
     "extend-shallow": "^2.0.1",
-    "opalcss": "0.0.2",
-    "promise": "^7.0.4"
+    "opalcss": "^0.0.2",
   }
 }


### PR DESCRIPTION
Because PostCSS exposed both APIs from one way.

I dont know what they do internally, but it's their job and i think they just expose promises for more easy use.

And it's no matter what they do, actually. Our `renderAsync` would just use `render` and `postcss` core anyways.
